### PR TITLE
The deprecation message for 'require "capybara-screenshot-diff"' should list the line in the user code where it is called.

### DIFF
--- a/lib/capybara-screenshot-diff.rb
+++ b/lib/capybara-screenshot-diff.rb
@@ -1,11 +1,3 @@
 # frozen_string_literal: true
 
-warn <<~MSG
-
-  DEPRECATED: use 'require "capybara_screenshot_diff/minitest"' instead of 'require "capybara-screenshot-diff"'
-      in #{caller(3)&.first}. 
-      "capybara-screenshot-diff" is no longer needed and will be removed in the next major release.
-
-MSG
-
 require "capybara_screenshot_diff/minitest"

--- a/lib/capybara/screenshot/diff.rb
+++ b/lib/capybara/screenshot/diff.rb
@@ -1,11 +1,3 @@
 # frozen_string_literal: true
 
-warn <<~MSG
-
-  DEPRECATED: use 'require "capybara_screenshot_diff/minitest"' or 'require "capybara_screenshot_diff/rspec"' instead of 'require "capybara/screenshot/diff"'
-      in #{caller(3)&.first}. 
-      "capybara/screenshot/diff" is no longer needed and will be removed in the next major release.
-
-MSG
-
 require "capybara_screenshot_diff/minitest"

--- a/lib/capybara_screenshot_diff/minitest.rb
+++ b/lib/capybara_screenshot_diff/minitest.rb
@@ -3,6 +3,17 @@
 require "minitest"
 require "capybara_screenshot_diff/dsl"
 
+used_deprecated_entrypoint = caller.any? do |path|
+  path.include?("capybara-screenshot-diff.rb") || path.include?("capybara/screenshot/diff.rb")
+end
+
+if used_deprecated_entrypoint
+  warn <<~MSG
+    [DEPRECATION] The default activation of `capybara_screenshot_diff/minitest` will be removed. 
+                  Please `require "capybara_screenshot_diff/minitest"` explicitly.
+  MSG
+end
+
 module CapybaraScreenshotDiff
   module Minitest
     module Assertions


### PR DESCRIPTION
@pftg This makes it easier for the developer to make the change and will make the transition smoother.

@pftg Can you add this?