### PR TITLE
Include CapybaraScreenshotDiff::DSL in all RSpec system tests by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ include the `CapybaraScreenshotDiff::DSL` in your test classes.
 It adds `match_screenshot` matcher to RSpec.
 
 > **Important**:
-> The `CapybaraScreenshotDiff::DSL` is automatically included in all feature tests by default.
+> The `CapybaraScreenshotDiff::DSL` is automatically included in all feature and system tests by default.
 
 
 ```ruby

--- a/lib/capybara_screenshot_diff/rspec.rb
+++ b/lib/capybara_screenshot_diff/rspec.rb
@@ -14,6 +14,7 @@ end
 
 RSpec.configure do |config|
   config.include ::CapybaraScreenshotDiff::DSL, type: :feature
+  config.include ::CapybaraScreenshotDiff::DSL, type: :system
 
   config.after do
     if self.class.include?(::CapybaraScreenshotDiff::DSL) && ::Capybara::Screenshot.active?


### PR DESCRIPTION
System tests are an evolution of feature tests that are also likely to use Capybara.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded the documentation to clarify that the DSL is included in both feature and system tests.
	- Enhanced RSpec configuration to include screenshot diffing capabilities for system tests, in addition to feature tests.
  
- **Documentation**
	- Updated the README file to reflect the broader scope of the DSL's automatic inclusion in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->