### PR TITLE
Relax rails version constraints

### DIFF
--- a/capybara-screenshot-diff.gemspec
+++ b/capybara-screenshot-diff.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "actionpack", ">= 6.1", "< 8"
+  spec.add_runtime_dependency "actionpack", ">= 6.1", "< 9"
   spec.add_runtime_dependency "capybara", ">= 2", "< 4"
 end

--- a/lib/capybara/screenshot/diff/version.rb
+++ b/lib/capybara/screenshot/diff/version.rb
@@ -3,7 +3,7 @@
 module Capybara
   module Screenshot
     module Diff
-      VERSION = "1.9.1"
+      VERSION = "1.9.10"
     end
   end
 end

--- a/lib/capybara/screenshot/diff/version.rb
+++ b/lib/capybara/screenshot/diff/version.rb
@@ -3,7 +3,7 @@
 module Capybara
   module Screenshot
     module Diff
-      VERSION = "1.9.10"
+      VERSION = "1.9.1"
     end
   end
 end


### PR DESCRIPTION
Addresses: https://github.com/snap-diff/snap_diff-capybara/issues/134.

From some local testing, I didn't find any apparent issues with one of my Rails 8.x projects and running system tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `actionpack` runtime dependency to support versions up to, but not including, `9`.
  
- **Version Updates**
	- Incremented the version of the `Capybara::Screenshot::Diff` module from `1.9.1` to `1.9.10`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->