### PR TITLE
Avoid deprecation warning with Minitest

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,8 +580,8 @@ If need to setup explicitly Vips driver, there are several ways to do this:
 * Globally: `Capybara::Screenshot::Diff.driver = :vips`
 * Per screenshot option: `screenshot 'index', driver: :vips`
 
-With enabled VIPS there are new alternatives to process differences, which easier to find and support.
-For example, `shift_distance_limit` is very heavy operation. Instead better to use `median_filter_window_size`.
+With enabled VIPS there are new alternatives to process differences, which are easier to find and support.
+For example, `shift_distance_limit` is a very heavy operation. Instead, use `median_filter_window_size`.
 
 #### Tolerance level (vips only)
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ gem 'capybara-screenshot-diff'
 gem 'oily_png', platform: :ruby
 ```
 
+Minitest users will want to do the following to avoid a deprecation warning:
+
+```ruby
+gem 'capybara-screenshot-diff', require: false
+gem 'oily_png', platform: :ruby
+```
+
 And then execute:
 
     $ bundle
@@ -64,7 +71,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include CapybaraScreenshotDiff::DSL
   # Make `assert_*` methods behave like Minitest assertions
   include CapybaraScreenshotDiff::Minitest::Assertions
-  
+
   def test_my_feature
     visit '/'
     assert_matches_screenshot 'index'
@@ -83,7 +90,7 @@ It adds `match_screenshot` matcher to RSpec.
 
 
 ```ruby
-require 'capybara_screenshot_diff/rspec' 
+require 'capybara_screenshot_diff/rspec'
 
 describe 'Permissions admin', type: :feature do
   it 'works with permissions' do
@@ -95,7 +102,7 @@ end
 
 describe 'Permissions admin', type: :non_feature do
   include CapybaraScreenshotDiff::DSL
-  
+
   it 'works with permissions' do
     visit('/')
     expect(page).to match_screenshot('home_page')
@@ -574,7 +581,7 @@ If need to setup explicitly Vips driver, there are several ways to do this:
 * Per screenshot option: `screenshot 'index', driver: :vips`
 
 With enabled VIPS there are new alternatives to process differences, which easier to find and support.
-For example, `shift_distance_limit` is very heavy operation. Instead better to use `median_filter_window_size`. 
+For example, `shift_distance_limit` is very heavy operation. Instead better to use `median_filter_window_size`.
 
 #### Tolerance level (vips only)
 


### PR DESCRIPTION
The deprecation warning:

```bash
[DEPRECATION] The default activation of `capybara_screenshot_diff/minitest` will be removed. 
              Please `require "capybara_screenshot_diff/minitest"` explicitly.
```

appears when running Rails system test, even when `application_system_test_case.rb` contains `require "capybara_screenshot_diff/minitest"`.

I found that adding `require: false` in the `Gemfile` fixed the problem, and thought it would save someone some confusion if it was mentioned in the `README`. If there's a better solution, feel free to ignore and close this PR.

My editor removed some blanks at the ends of lines, which triggered CodeRabbit to suggest another change. It look reasonable, so I made the suggested change (and one other small correction that I noticed just above it).

This is a very useful gem. Thanks for your work on it!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated README with a note for Minitest users to specify `require: false` for the gem to avoid deprecation warnings.
  - Cleaned up whitespace in code examples for Minitest and RSpec sections.
  - Removed a trailing space in the VIPS image processing driver section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->