### PR TITLE
test: new ruby 3.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,9 @@ jobs:
           - ruby-version: jruby-9.4
             gemfile: rails80_gems.rb
             experimental: false
+          - ruby-version: jruby-9.4
+            gemfile: rails81_gems.rb
+            experimental: false
         include:
           - ruby-version: 3.5.0-preview1
             gemfile: rails81_gems.rb

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,10 +95,10 @@ jobs:
       matrix:
         ruby-version: [ 3.4, 3.3, 3.2, jruby-9.4, jruby-10.0 ]
         gemfile:
-          - rails70_gems.rb
           - rails71_gems.rb
           - rails72_gems.rb
           - rails80_gems.rb
+          - rails81_gems.rb
         experimental: [ false ]
         exclude:
           # We already tested last version
@@ -111,7 +111,10 @@ jobs:
             experimental: false
         include:
           - ruby-version: 3.5.0-preview1
-            gemfile: edge_gems
+            gemfile: rails81_gems.rb
+            experimental: true
+          - ruby-version: 3.5.0-preview1
+            gemfile: edge_gems.rb
             experimental: true
           - ruby-version: 3.4
             gemfile: edge_gems.rb

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,9 @@ jobs:
             gemfile: rails80_gems.rb
             experimental: false
         include:
+          - ruby-version: 3.5.0-preview1
+            gemfile: edge_gems
+            experimental: true
           - ruby-version: 3.4
             gemfile: edge_gems.rb
             experimental: true

--- a/gemfiles/rails81_gems.rb
+++ b/gemfiles/rails81_gems.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+gems = "#{File.dirname __dir__}/gems.rb"
+eval File.read(gems), binding, gems
+
+gem "activesupport", "~> 8.1.0.beta1"
+gem "actionpack", "~> 8.1.0.beta1"

--- a/lib/capybara/screenshot/diff/area_calculator.rb
+++ b/lib/capybara/screenshot/diff/area_calculator.rb
@@ -48,7 +48,7 @@ module Capybara
         def build_regions_for(coordinates)
           coordinates
             .map { |entry| Region.from_edge_coordinates(*entry) }
-            .tap { |it| it.compact! }
+            .tap { |region| region.compact! }
         end
       end
     end

--- a/lib/capybara_screenshot_diff/screenshot_assertion.rb
+++ b/lib/capybara_screenshot_diff/screenshot_assertion.rb
@@ -18,9 +18,9 @@ module CapybaraScreenshotDiff
       return screenshot_job if screenshot_job.is_a?(ScreenshotAssertion)
 
       caller, name, compare = screenshot_job
-      ScreenshotAssertion.new(name).tap do |it|
-        it.caller = caller
-        it.compare = compare
+      ScreenshotAssertion.new(name).tap do |assertion|
+        assertion.caller = caller
+        assertion.compare = compare
       end
     end
 

--- a/test/support/test_helpers.rb
+++ b/test/support/test_helpers.rb
@@ -4,6 +4,7 @@ require "support/test_doubles"
 
 module TestHelpers
   include Capybara::Screenshot::Diff::TestDoubles
+
   # Common assertions for image comparison tests
   module Assertions
     # Asserts that a dimension check was called a specific number of times


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * CI matrix updated to add experimental runs for Ruby 3.5.0-preview1 (Rails 8.1 and edge), added Rails 8.1 to options, and removed Rails 7.0 from the matrix; added/excluded JRuby rows for specific combinations.
* **Style / Refactor**
  * Minor whitespace and local-variable renaming in test and assertion code with no behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->